### PR TITLE
Added (Terminal) Game Seed Sharing to Client/Server

### DIFF
--- a/NetworkCode/Client/Client.cpp
+++ b/NetworkCode/Client/Client.cpp
@@ -19,6 +19,59 @@
 
 using namespace std;
 
+struct Post {
+	string seed;
+	string user;
+	string text;
+};
+
+struct Node {
+	Post data;
+	Node *next;
+};
+
+class List {
+	private:
+		Node *head, *tail;
+	public:
+		List() :head{nullptr}, tail{nullptr} {}
+		void createNode(Post d) {
+			Node *temp = new Node;
+			temp->data = d;
+			temp->next = nullptr;
+			if(head == nullptr) {
+				head = temp;
+				tail = temp;
+				temp = nullptr;
+			}
+			else {
+				tail->next = temp;
+				tail = temp;
+			}
+		}
+		void printList() {
+			Node *temp = new Node;
+			temp = head;
+			int counter = 1;
+			while(temp != nullptr) {
+				cout << "Seed #" << counter << ": " << temp->data.seed << "\nUser: " << temp->data.user << "\nMessage: " 
+				<< temp->data.text << "\n\n" << endl;
+				temp = temp->next;
+				counter++;
+			}
+		}
+		string toString() {
+			Node *temp = new Node;
+			temp = head;
+			stringstream ss;
+			while(temp != nullptr) {
+				ss << temp->data.seed << "\n" << temp->data.user << "\n" << temp->data.text << "\n";
+				temp = temp->next;
+			}
+			return ss.str();
+		}
+};
+
 int main(int argc, char *argv[])
 {
     int sockfd, fdmax;
@@ -72,50 +125,142 @@ int main(int argc, char *argv[])
     }
 
     freeaddrinfo(servinfo);
+	int choice = -1;
+	cout << "Enter 0 for chat and 1 for game seed sharing: ";
+	cin >> choice;
+	
+	if(choice == 0) {
+	
+		// Do-while loop to send and receive data
+		char buf[4096];
+		string userInput;
+		FD_SET(sockfd, &master);
 
-    // Do-while loop to send and receive data
-    char buf[4096];
-    string userInput;
-    FD_SET(sockfd, &master);
-    bool firstTime = true;
+		do
+		{
+			temp = master;
 
-    do
-    {
-    	temp = master;
+			select(sockfd+1, &temp, nullptr, nullptr, &tv);
 
-    	select(sockfd+1, &temp, nullptr, nullptr, &tv);
+			if (FD_ISSET(STDIN, &temp))
+			{
+				getline(cin, userInput);
 
-    	if (FD_ISSET(STDIN, &temp))
-    	{
-	        getline(cin, userInput);
-
-	        if (userInput.size() > 0) // Make sure the user has typed in something
-	        {
-	            // Send the text
-	            int sendResult = send(sockfd, userInput.c_str(), userInput.size() + 1, 0);
-	            if (sendResult <= 0)
-	            {
-	            	break;
-	            }
-	        }
-	    }
-	    else
-	    {
-    		// Get response
-        	memset(&buf, 0, sizeof buf);
-            int bytesReceived = recv(sockfd, buf, 4096, 0);
-       	    if (bytesReceived > 0)
-            {
-                cout << string(buf, 0, bytesReceived) << endl;
-                firstTime = false;
-            }
-            else
-            {
-            	break;
-            }
-	    }
-    
-    } while (userInput != "exit");
+				if (userInput.size() > 0) // Make sure the user has typed in something
+				{
+					// Send the text
+					int sendResult = send(sockfd, userInput.c_str(), userInput.size() + 1, 0);
+					if (sendResult <= 0)
+					{
+						break;
+					}
+				}
+			}
+			else
+			{
+				// Get response
+				memset(&buf, 0, sizeof buf);
+				int bytesReceived = recv(sockfd, buf, 4096, 0);
+				if (bytesReceived > 0)
+				{
+					cout << string(buf, 0, bytesReceived) << endl;
+				}
+				else
+				{
+					break;
+				}
+			}
+		
+		} while (userInput != "exit");
+	}
+	else {
+		char buf[4096];
+		cout << "\n";
+		
+		//Receive data from server (to get past initial message)
+		memset(&buf, 0, sizeof buf);
+		int bytesReceived = recv(sockfd, buf, 4096, 0);
+		
+		//Randomly generated string, if server sees this then knows to send specific data
+		string input = "uDN0oyTNjaAENW9KLocdjXP85ou3bAtBAhBAOPXLU8P0Iip8AcaELgAvewFNTpzM";
+		int sendResult = send(sockfd, input.c_str(), input.size() + 1, 0);
+		
+		List posts;
+		Post p;
+		
+		//Receive data from server
+		memset(&buf, 0, sizeof buf);
+		bytesReceived = recv(sockfd, buf, 4096, 0);
+		
+		//Put data into linked list and print
+		if(bytesReceived > 1) {
+			int i = 0;
+			int counter = 0;
+			string add = "";
+			
+			while(buf[i] != '\0') {
+				if(buf[i] == '\n') {
+					counter++;
+					if(counter % 3 == 1) {
+						p.seed = add;
+						add = "";
+					}
+					else if(counter % 3 == 2) {
+						p.user = add;
+						add = "";
+					}
+					else {
+						p.text = add;
+						posts.createNode(p);
+						add = "";
+					}
+				}
+				else {
+					add += buf[i];
+				}
+				i++;
+			}
+			posts.printList();
+		}
+		else {
+			cout << "No seeds shared yet\n" << endl;
+		}
+		
+		choice = 0;
+		while(choice == 0) {
+			cout << "Enter 0 to share a game seed or 1 to exit: ";
+			cin >> choice;
+			
+			if(choice != 0) {
+				break;
+			}
+			
+			cout << "\nEnter Game Seed: ";
+			cin >> p.seed;
+			cout << "\nEnter User: ";
+			cin >> p.user;
+			cout << "\nEnter Message: ";
+			if(cin.peek() == '\n') {
+				cin.ignore();
+			}
+			getline(cin, p.text);
+			posts.createNode(p);
+			
+			input = posts.toString();
+			input += "uDN0oyTNjaAENW9KLocdjXP85ou3bAtBAhBAOPXLU8P0Iip8AcaELgAvewFNTpzM";
+			
+			sendResult = send(sockfd, input.c_str(), input.size() + 1, 0);
+			
+			memset(&buf, 0, sizeof buf);
+			bytesReceived = recv(sockfd, buf, 4096, 0);
+			
+			if(bytesReceived > 0) {
+				cout << "\n\n" << buf << endl;
+				cout << "Updated List\n" << endl;
+				posts.printList();
+			}
+		}
+	}
 
     //Shut her down
     close(sockfd);

--- a/NetworkCode/Client/Makefile
+++ b/NetworkCode/Client/Makefile
@@ -7,4 +7,4 @@ COMPILER_FLAGS = -w
 OBJ_NAME = Client
 
 all: $(OBJS)
-	$(CC) $(OBJS) $(COMPILER_FLAGS) -o $(OBJ_NAME)
+	$(CC) $(OBJS) $(COMPILER_FLAGS) -o $(OBJ_NAME) -std=gnu++11


### PR DESCRIPTION
Now the user can select between the chat and the game seed sharing service

How it works as of now: Client sends 64 length string (I randomly generated it) to know that it specifically wants to game seed data from "forum_data.txt" (txt name will likely change). This data is sent to the client (only the one with the listening socket) and displayed. The Client then has the option to exit or add new data to the game seed sharing service. If chosen to add, the user adds the seed, their username (which will be automatically done instead when users is implemented) and their message about the seed. This data is then send back over to the server but with the same 64 length string added so the server knows it needs to write the data into "forum_data.txt". The data is written and a success is sent back to the client, and the client can add another seed or exit from there.